### PR TITLE
Rename `on('selectionchange')` to `on('select')`

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -156,7 +156,7 @@ export interface EditorOptions<
 
 type EditorEventMap = {
   change: () => void;
-  selectionchange: () => void;
+  select: () => void;
   readonly: () => void;
 };
 
@@ -347,7 +347,7 @@ export const createEditor = <
       (selection[0] !== s[0] || selection[1] !== s[1])
     ) {
       selection = s;
-      publish("selectionchange");
+      publish("select");
     }
   };
 

--- a/src/plugins/debug.ts
+++ b/src/plugins/debug.ts
@@ -7,7 +7,7 @@ export function debugPlugin(editor: Editor) {
   editor.on("change", () => {
     console.log("change", editor.doc);
   });
-  editor.on("selectionchange", () => {
-    console.log("selectionchange", editor.selection);
+  editor.on("select", () => {
+    console.log("select", editor.selection);
   });
 }


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement/select_event