### PR TITLE
fix: finalize active IME composition before a programmatic edit

### DIFF
--- a/e2e/composition.spec.ts
+++ b/e2e/composition.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "@playwright/test";
+import { getText, initEditateHelpers } from "./editate";
+import { getEditable, storyUrl } from "./utils";
+
+test.beforeEach(async ({ context }) => {
+  await initEditateHelpers(context);
+});
+
+test.describe("programmatic edit during composition", () => {
+  // A consumer edit (editor.exec / editor.apply) dispatched while an IME
+  // composition is active must not be reverted when the composition ends.
+  // Without finalizing the composition first, the edit's re-render is recorded
+  // as part of the composition and reverted at compositionend (#372).
+  test("survives compositionend", async ({ page }) => {
+    await page.goto(
+      storyUrl(
+        "basics-programmatic-edit--programmatic-edit-during-composition",
+      ),
+    );
+    const editable = await getEditable(page);
+    await editable.focus();
+
+    // Put a caret mid-word and open a composition (turns editate's mutation
+    // recording on), then fire a programmatic edit while it's active.
+    await editable.evaluate((el) => {
+      const node = el.querySelector("div")!.firstChild!;
+      const range = el.ownerDocument.createRange();
+      range.setStart(node, 5);
+      range.collapse(true);
+      const selection = el.ownerDocument.getSelection()!;
+      selection.removeAllRanges();
+      selection.addRange(range);
+
+      el.dispatchEvent(new CompositionEvent("compositionstart", { bubbles: true }));
+      el.dispatchEvent(
+        new InputEvent("beforeinput", {
+          inputType: "insertCompositionText",
+          data: "x",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+      (window as unknown as { __repro: { insert(): void } }).__repro.insert();
+    });
+
+    // Let the consumer's re-render flush, then end the composition.
+    await page.waitForTimeout(50);
+    await editable.evaluate((el) =>
+      el.dispatchEvent(
+        new CompositionEvent("compositionend", { bubbles: true, data: "x" }),
+      ),
+    );
+    await page.waitForTimeout(50);
+
+    expect((await getText(editable)).join("\n")).toContain("[INSERTED]");
+  });
+});

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -459,6 +459,9 @@ export const createEditor = <
       let isComposing = false;
       let hasFocus = false;
       let isDragging = false;
+      // True only while flushInput is finalizing a composition, so the apply
+      // hook below doesn't recurse when flushInput dispatches its own ops.
+      let flushing = false;
 
       const document = getCurrentDocument(element);
 
@@ -516,6 +519,7 @@ export const createEditor = <
       };
 
       const flushInput = () => {
+        flushing = true;
         const queue = observer._flush();
 
         observer._record(false);
@@ -544,7 +548,21 @@ export const createEditor = <
           inputTransaction = null;
         }
         isComposing = false;
+        flushing = false;
       };
+
+      // A programmatic edit (paste, toolbar insert, image insert, …) dispatched
+      // while an IME composition is active must finalize that composition
+      // first. Otherwise it lands inside the composing region and is reverted
+      // when the composition ends — on Android, GBoard re-composes the word
+      // under the caret, so even a bare-caret paste hits this. The `flushing`
+      // guard breaks the recursion from flushInput's own apply().
+      const unhookApply = editor.hook("apply", (_op, next) => {
+        if (isComposing && !flushing) {
+          flushInput();
+        }
+        next();
+      });
 
       // spec compliant: keydown -> beforeinput -> input (-> keyup)
       // Safari (IME)  : beforeinput -> input -> keydown (-> keyup)
@@ -761,6 +779,7 @@ export const createEditor = <
         element.style.whiteSpace = prevWhiteSpace;
 
         observer._dispose();
+        unhookApply();
 
         document.removeEventListener("selectionchange", onSelectionChange);
         element.removeEventListener("keydown", onKeyDown);

--- a/stories/basics/programmatic-edit.stories.tsx
+++ b/stories/basics/programmatic-edit.stories.tsx
@@ -1,0 +1,119 @@
+import React, { useEffect, useRef, useState } from "react";
+import type { StoryObj } from "@storybook/react-vite";
+import { createPlainEditor, ReplaceText } from "../../src";
+
+export default {
+  component: createPlainEditor,
+};
+
+/**
+ * Repro: a **programmatic edit** (`editor.exec` / `editor.apply`) made while an
+ * **IME composition is active** is reverted when the composition ends.
+ *
+ * editate records DOM mutations during a composition so it can revert the IME's
+ * provisional changes at `compositionend`. But a consumer's programmatic edit
+ * also mutates the DOM (via the consumer's re-render) mid-composition — that
+ * mutation gets caught in the same recording and reverted too, silently
+ * dropping the edit and leaving the model and DOM out of sync.
+ *
+ * Only reproducible with a composing IME (e.g. Android GBoard): a hardware
+ * keyboard commits each keystroke, so there is no open composition to fight.
+ *
+ * The insert is fired from a `setTimeout` (not a button press) on purpose — so
+ * it lands while the editor keeps focus and the word is still composing, with
+ * no pointer/blur ending the composition first.
+ */
+export const ProgrammaticEditDuringComposition: StoryObj = {
+  render: () => {
+    const ref = useRef<HTMLDivElement>(null);
+    const textRef = useRef("hello world");
+    const [text, setText] = useState("hello world");
+    const [status, setStatus] = useState("idle — press the button to start");
+
+    useEffect(() => {
+      const el = ref.current;
+      if (!el) return;
+      const editor = createPlainEditor({
+        text: textRef.current,
+        onChange: (t) => {
+          textRef.current = t;
+          setText(t);
+        },
+      });
+      const cleanup = editor.input(el);
+
+      const insert = () => editor.exec(ReplaceText, " [INSERTED] ");
+      (window as unknown as { __repro: unknown }).__repro = {
+        editor,
+        host: el,
+        insert,
+        dom: () => el.textContent,
+        model: () => textRef.current,
+      };
+
+      return () => {
+        cleanup();
+        delete (window as unknown as { __repro?: unknown }).__repro;
+      };
+    }, []);
+
+    const schedule = () => {
+      setStatus("⏳ 3s — tap into the editor and type a word, leave it underlined");
+      setTimeout(() => {
+        (window as unknown as { __repro: { insert(): void } }).__repro.insert();
+        setStatus("✅ inserted ' [INSERTED] ' — now tap elsewhere to commit the word");
+      }, 3000);
+    };
+
+    return (
+      <div style={{ fontFamily: "sans-serif", maxWidth: 640, padding: 8 }}>
+        <ol style={{ fontSize: 14, lineHeight: 1.5 }}>
+          <li>
+            On an <b>Android</b> device (GBoard).
+          </li>
+          <li>
+            Press <b>Schedule insert</b>.
+          </li>
+          <li>
+            Within 3s, tap into the editor and type a word, leaving it{" "}
+            <b>composing</b> (underlined — no space).
+          </li>
+          <li>
+            At 3s, <code>[INSERTED]</code> is inserted programmatically — you'll
+            see it appear.
+          </li>
+          <li>
+            Now <b>tap elsewhere</b> to commit the composing word.
+          </li>
+        </ol>
+        <p style={{ fontSize: 14 }}>
+          <b>Expected:</b> <code>[INSERTED]</code> stays. <b>Bug:</b> it's
+          reverted at <code>compositionend</code> — gone from the editor, but
+          still in the model (they desync).
+        </p>
+        <button
+          onClick={schedule}
+          style={{ fontSize: 16, padding: "8px 14px", marginBottom: 8 }}
+        >
+          Schedule insert (3s)
+        </button>
+        <div
+          ref={ref}
+          style={{
+            backgroundColor: "white",
+            border: "solid 1px darkgray",
+            padding: 8,
+            minHeight: 60,
+            fontSize: 22,
+          }}
+        >
+          {text.split("\n").map((r, i) => (
+            <div key={i}>{r ? r : <br />}</div>
+          ))}
+        </div>
+        <pre style={{ fontSize: 13, whiteSpace: "pre-wrap" }}>{status}</pre>
+        <pre style={{ fontSize: 13 }}>model text: {JSON.stringify(text)}</pre>
+      </div>
+    );
+  },
+};


### PR DESCRIPTION
Fixes #372.

A programmatic edit (`editor.exec` / `editor.apply`) dispatched during an active IME composition is recorded and reverted at `compositionend` — details in #372.

This registers an `apply` hook that finalizes any active composition before the programmatic edit runs, so it applies to a stable document:

```ts
let flushing = false; // set around flushInput()'s body
const unhookApply = editor.hook("apply", (_op, next) => {
  if (isComposing && !flushing) flushInput();
  next();
});
```

`flushing` breaks the re-entrancy from `flushInput`'s own `apply(inputTransaction)`. Includes `stories/basics/programmatic-edit.stories.tsx`, the repro from #372.

Independent of #370 (honoring a composition-ending tap).
