### PR TITLE
Delete one code point on backspace instead of a whole grapheme cluster

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -10,7 +10,11 @@ import {
 import { createMutationObserver } from "./dom/mutation.js";
 import type { DocNode, Fragment, Selection } from "./doc/types.js";
 import { isFunction, isString, microtask } from "./utils.js";
-import { domSelectionToSelection, positionToOffset } from "./doc/node.js";
+import {
+  domSelectionToSelection,
+  positionToOffset,
+  sliceText,
+} from "./doc/node.js";
 import {
   applyOperation,
   type Operation,
@@ -24,6 +28,67 @@ import { historyPlugin } from "./plugins/history.js";
 import type { Parser } from "./dom/parser.js";
 
 const empty: unknown[] = [];
+
+const ZWJ = 0x200d;
+const KEYCAP = 0x20e3;
+// Variation selectors (text/emoji presentation).
+const isVariationSelector = (c: number) => c === 0xfe0e || c === 0xfe0f;
+// Regional indicators (flags) and emoji modifiers (skin tones).
+const isEmojiGlue = (c: number) =>
+  c === ZWJ ||
+  c === KEYCAP ||
+  isVariationSelector(c) ||
+  (c >= 0x1f1e6 && c <= 0x1f1ff) ||
+  (c >= 0x1f3fb && c <= 0x1f3ff);
+
+const codePointSizeAt = (text: string, i: number) =>
+  text.codePointAt(i)! > 0xffff ? 2 : 1;
+
+const lastCodePointSize = (text: string) => {
+  const c = text.charCodeAt(text.length - 1);
+  // A low surrogate means the last code point is a pair.
+  return c >= 0xdc00 && c <= 0xdfff && text.length > 1 ? 2 : 1;
+};
+
+/**
+ * Browsers expand backward/forward deletion to a whole grapheme cluster. For
+ * scripts whose clusters span several code points - Khmer and other Brahmic
+ * scripts, Thai, Hangul jamo, combining marks - that wipes out an entire
+ * syllable per keystroke, while users expect deletion to be per character.
+ *
+ * Narrow the range to a single code point, except for emoji sequences (ZWJ
+ * sequences, flags, skin tones, keycaps, variation selectors), which are only
+ * meaningful as a whole and so keep the browser's cluster range.
+ */
+const narrowDeletion = (
+  [start, end]: Selection,
+  text: string,
+  backward: boolean,
+): Selection => {
+  if (backward) {
+    const size = lastCodePointSize(text);
+    const last = text.codePointAt(text.length - size)!;
+    if (isEmojiGlue(last)) return [start, end];
+    // The trailing code point may be the tail of a ZWJ sequence.
+    if (text.length > size) {
+      const prevSize = lastCodePointSize(text.slice(0, -size));
+      if (isEmojiGlue(text.codePointAt(text.length - size - prevSize)!)) {
+        return [start, end];
+      }
+    }
+    return [Math.max(start, end - size), end];
+  }
+
+  const size = codePointSizeAt(text, 0);
+  // The leading code point may be the head of a ZWJ sequence.
+  if (
+    isEmojiGlue(text.codePointAt(0)!) ||
+    (text.length > size && isEmojiGlue(text.codePointAt(size)!))
+  ) {
+    return [start, end];
+  }
+  return [start, Math.min(end, start + size)];
+};
 
 const noop = () => {};
 
@@ -629,10 +694,22 @@ export const createEditor = <
           }
           const ops = inputTransaction[0];
 
-          const range = domSelectionToSelection(
+          let range = domSelectionToSelection(
             doc,
             serializeRange(element, parser, domRange),
           );
+          if (
+            (inputType === "deleteContentBackward" ||
+              inputType === "deleteContentForward") &&
+            isCollapsed(selection) &&
+            !isCollapsed(range)
+          ) {
+            range = narrowDeletion(
+              range,
+              sliceText(doc, range[0], range[1]),
+              inputType === "deleteContentBackward",
+            );
+          }
           if (!isCollapsed(range)) {
             // replace or delete
             ops.push({ type: "delete", range });

--- a/stories/basics/plain.stories.tsx
+++ b/stories/basics/plain.stories.tsx
@@ -398,6 +398,45 @@ two !
   },
 };
 
+export const Khmer: StoryObj = {
+  render: () => {
+    const ref = useRef<HTMLDivElement>(null);
+    const [text, setText] = useState(`ភាសាខ្មែរ
+សូមស្វាគមន៍មកកាន់ប្រទេសកម្ពុជា។
+ស្រុក ខ្ញុំ ស្អាត ណាស់។`);
+    useEffect(() => {
+      if (!ref.current) return;
+      return createPlainEditor({
+        text: text,
+        onChange: setText,
+      }).input(ref.current);
+    }, []);
+    return (
+      <div>
+        <p>
+          Khmer syllables are single grapheme clusters made of several code
+          points (base + coeng + subscript + vowels/diacritics). Backspace
+          should remove one code point at a time, not the whole syllable.
+        </p>
+        <div
+          ref={ref}
+          style={{
+            backgroundColor: "white",
+            border: "solid 1px darkgray",
+            padding: 8,
+            fontSize: 20,
+            lineHeight: 1.8,
+          }}
+        >
+          {text.split("\n").map((r, i) => (
+            <div key={i}>{r ? r : <br />}</div>
+          ))}
+        </div>
+      </div>
+    );
+  },
+};
+
 export const Vertical: StoryObj = {
   render: () => {
     const ref = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
Backspace currently deletes a whole grapheme cluster because the range comes straight from the browser's `getTargetRanges()`. In Khmer that means one backspace wipes out an entire syllable like `ស្រុក`, which isn't what people expect while typing. The same thing happens in Devanagari, Thai, Hangul jamo and with combining accents.

This narrows backward/forward deletion to a single code point when the caret is collapsed. Emoji sequences (ZWJ, flags, skin tones, keycaps, variation selectors) are left alone and still delete as one unit, since deleting half of them makes no sense.

Selection deletes and word/line deletes are untouched.

Also added a Khmer story under Basics/Plain to try it out.
