### PR TITLE
Tolerate framework anchor nodes (e.g. Svelte's {#each}) in selection and delete

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -3,7 +3,7 @@
     "name": "Editor",
     "path": "lib/index.js",
     "import": "{ createEditor }",
-    "limit": "5.75 kB"
+    "limit": "6 kB"
   },
   {
     "name": "Total",

--- a/src/dom/index.spec.ts
+++ b/src/dom/index.spec.ts
@@ -1307,3 +1307,69 @@ const elToString = (element: Element): string => {
     expect(serializePosition(doc, parser, ...domPos2)).toEqual(pos);
   });
 }
+
+// Framework anchor nodes — comment / empty text nodes that frameworks (e.g.
+// Svelte's `{#each}`) intersperse around the real blocks. A boundary must never
+// stick to one: Firefox's Ctrl+A parks the end boundary on a trailing anchor,
+// which previously climbed to the root and miscounted the inter-block
+// separators (dropping the last character on delete).
+{
+  const comment = () => document.createComment("");
+  const emptyText = () => document.createTextNode("");
+  const build = (children: Node[]): HTMLElement => {
+    const root = document.createElement("div");
+    children.forEach((c) => root.appendChild(c));
+    return root;
+  };
+
+  it("trailing empty-text anchor: Ctrl+A end resolves to end of last block", () => {
+    const doc = build([h("p", ["Hello"]), h("p", ["world"]), emptyText()]);
+    // Firefox Ctrl+A: (root, 0)..(root, childCount)
+    expect(serializePosition(doc, parser, doc, 0)).toEqual([[0], 0]);
+    expect(serializePosition(doc, parser, doc, 3)).toEqual([[1], 5]);
+    // just before the trailing anchor is still the end of the document
+    expect(serializePosition(doc, parser, doc, 2)).toEqual([[1], 5]);
+    // round-trips through findPosition
+    const domPos = toRange(findPosition(doc, parser, [[1], 5]));
+    expect(serializePosition(doc, parser, ...domPos)).toEqual([[1], 5]);
+  });
+
+  it("trailing comment anchor: Ctrl+A end resolves to end of last block", () => {
+    const doc = build([h("p", ["Hello"]), h("p", ["world"]), comment()]);
+    expect(serializePosition(doc, parser, doc, 0)).toEqual([[0], 0]);
+    expect(serializePosition(doc, parser, doc, 3)).toEqual([[1], 5]);
+  });
+
+  it("comments interspersed around every block", () => {
+    const doc = build([
+      comment(),
+      h("p", ["Hello"]),
+      comment(),
+      h("p", ["world"]),
+      comment(),
+    ]);
+    expect(serializePosition(doc, parser, doc, 0)).toEqual([[0], 0]);
+    expect(serializePosition(doc, parser, doc, 5)).toEqual([[1], 5]);
+    // boundary on the comment between the blocks -> start of the next block
+    expect(serializePosition(doc, parser, doc, 2)).toEqual([[1], 0]);
+  });
+
+  it("empty-text anchor between blocks: caret on the anchor resolves forward", () => {
+    const anchor = emptyText();
+    const doc = build([h("p", ["Hello"]), anchor, h("p", ["world"])]);
+    // caret parked directly on the anchor node (the click / phantom-caret case)
+    expect(serializePosition(doc, parser, anchor, 0)).toEqual([[1], 0]);
+    // and via the parent-relative offset
+    expect(serializePosition(doc, parser, doc, 1)).toEqual([[1], 0]);
+  });
+
+  it("leading anchors resolve forward to the first block", () => {
+    const doc = build([comment(), emptyText(), h("p", ["Hello"])]);
+    expect(serializePosition(doc, parser, doc, 0)).toEqual([[0], 0]);
+    // caret parked directly on the leading comment
+    expect(serializePosition(doc, parser, doc.childNodes[0]!, 0)).toEqual([
+      [0],
+      0,
+    ]);
+  });
+}

--- a/src/dom/index.ts
+++ b/src/dom/index.ts
@@ -1,4 +1,9 @@
-import { type TokenType, type Parser, TOKEN_BLOCK } from "./parser.js";
+import {
+  type TokenType,
+  type Parser,
+  TOKEN_BLOCK,
+  isHiddenNode,
+} from "./parser.js";
 import type {
   DocNode,
   Selection as JsSelection,
@@ -9,7 +14,7 @@ import type {
 import { selectionToDomSelection } from "../doc/node.js";
 import { isCollapsed } from "../doc/position.js";
 import { min } from "../utils.js";
-import { isElementNode } from "./utils.js";
+import { isElementNode, isTextNode, isCommentNode } from "./utils.js";
 
 export {
   createParser,
@@ -179,6 +184,17 @@ export const findPosition = (
 };
 
 /**
+ * A node the tokenizer emits no selectable token for: empty text, a comment, or
+ * a hidden element. Frameworks (e.g. Svelte's `{#each}`) intersperse such
+ * "anchor" nodes around the real block elements.
+ * @internal
+ */
+export const isUnselectableNode = (node: Node): boolean =>
+  isCommentNode(node) ||
+  (isTextNode(node) && node.data.length === 0) ||
+  (isElementNode(node) && isHiddenNode(node));
+
+/**
  * @internal
  */
 export const serializePosition = (
@@ -206,6 +222,38 @@ export const serializePosition = (
     node = node.childNodes[index]!;
     excludeEnd = index === offsetAtNode;
     offsetAtNode = 0;
+  }
+
+  if (isUnselectableNode(node)) {
+    // Boundary landed on an anchor node (comment / empty text / hidden). The
+    // block-walk below would climb to the root and miscount the inter-block
+    // separators (e.g. Firefox's Ctrl+A parks the end boundary on a trailing
+    // anchor). Snap to the nearest selectable sibling: forward at the anchor's
+    // start, backward at its end; fall back to the other side when one has none.
+    const forward = excludeEnd;
+    let sibling: Node | null = node;
+    while (
+      (sibling = forward ? sibling!.nextSibling : sibling!.previousSibling)
+    ) {
+      if (!isUnselectableNode(sibling)) {
+        node = sibling;
+        offsetAtNode = 0;
+        break;
+      }
+    }
+    if (isUnselectableNode(node)) {
+      sibling = node;
+      while (
+        (sibling = forward ? sibling!.previousSibling : sibling!.nextSibling)
+      ) {
+        if (!isUnselectableNode(sibling)) {
+          node = sibling;
+          offsetAtNode = 0;
+          excludeEnd = !forward;
+          break;
+        }
+      }
+    }
   }
 
   return parse(

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -6,6 +6,7 @@ import {
   getPointedCaretPosition,
   defaultIsBlockNode,
   serializeRange,
+  isUnselectableNode,
 } from "./dom/index.js";
 import { createMutationObserver } from "./dom/mutation.js";
 import type { DocNode, Fragment, Selection } from "./doc/types.js";
@@ -554,6 +555,29 @@ export const createEditor = <
         );
       };
 
+      // The browser can park the caret on an anchor node (empty text / comment
+      // a framework interspersed between blocks). The serialized offset stays
+      // correct, but the visible caret sits on the anchor — Firefox renders it
+      // on a phantom line below the text when you click in the empty area.
+      // Re-write the DOM position so it snaps back into the real block. Only
+      // fires when an endpoint is on an anchor, so it's a no-op while editing.
+      const normalizeCaretOffAnchor = () => {
+        const sel = document.getSelection();
+        if (!sel) return;
+        const anchorNode = sel.anchorNode;
+        // Only inspect the focus endpoint when it differs from the anchor (a
+        // collapsed caret shares both), so the common case does one check.
+        if (
+          (anchorNode != null && isUnselectableNode(anchorNode)) ||
+          (sel.focusNode != null &&
+            sel.focusNode !== anchorNode &&
+            isUnselectableNode(sel.focusNode))
+        ) {
+          setSelectionToDOM(element, parser, doc, selection);
+          domSelection = selection;
+        }
+      };
+
       const flushInput = () => {
         const queue = observer._flush();
 
@@ -648,6 +672,22 @@ export const createEditor = <
           if (!isCollapsed(range)) {
             // replace or delete
             ops.push({ type: "delete", range });
+          } else if (data == null && inputType.startsWith("delete")) {
+            // A collapsed delete target range. Some browsers report a collapsed
+            // range for a Backspace/Delete that should cross a block boundary —
+            // notably Firefox when blocks are separated by framework anchor
+            // nodes. Fall back to deleting one position in the delete direction
+            // so the merge still happens; isValidSelection keeps a delete at the
+            // document edge a no-op.
+            const at = range[0];
+            const fallback: Selection | null = inputType.endsWith("Backward")
+              ? [at - 1, at]
+              : inputType.endsWith("Forward")
+                ? [at, at + 1]
+                : null;
+            if (fallback && isValidSelection(doc, fallback)) {
+              ops.push({ type: "delete", range: fallback });
+            }
           }
           if (data) {
             // replace or insert
@@ -672,6 +712,7 @@ export const createEditor = <
       const onFocus = () => {
         hasFocus = true;
         syncSelection();
+        normalizeCaretOffAnchor();
       };
       const onBlur = () => {
         hasFocus = false;
@@ -681,6 +722,7 @@ export const createEditor = <
         // Safari may dispatch selectionchange event after dragstart
         if (hasFocus && !isComposing && !isDragging) {
           syncSelection();
+          normalizeCaretOffAnchor();
         }
       };
 

--- a/src/editor.window.spec.ts
+++ b/src/editor.window.spec.ts
@@ -132,3 +132,72 @@ it("should sync selection and input with another document", async () => {
 
   dispose();
 });
+
+it("merges blocks on a collapsed deleteContentBackward target range", async () => {
+  // Firefox reports a collapsed target range for a Backspace that should cross a
+  // block boundary when blocks are separated by framework anchor nodes (e.g.
+  // Svelte's `{#each}`). The editor falls back to deleting one position backward
+  // so the two blocks still merge.
+  const { editor, element, getText, dispose } = init("a\nb");
+
+  element.dispatchEvent(new childWindow.FocusEvent("focus"));
+
+  // Caret at the very start of the second block ("b") — doc offset 2
+  // (block "a" is size 1, plus the inter-block separator).
+  setCaret(element.childNodes[1]!.firstChild!, 0);
+  await nextTask();
+  expect(editor.selection).toEqual([2, 2]);
+
+  const event = new childWindow.InputEvent("beforeinput", {
+    inputType: "deleteContentBackward",
+    bubbles: true,
+    cancelable: true,
+  });
+  (event as any).getTargetRanges = () => [
+    new childWindow.StaticRange({
+      startContainer: element.childNodes[1]!.firstChild!,
+      startOffset: 0,
+      endContainer: element.childNodes[1]!.firstChild!,
+      endOffset: 0,
+    }),
+  ];
+  element.dispatchEvent(event);
+  await nextTask();
+
+  expect(getText()).toBe("ab");
+  expect(editor.selection).toEqual([1, 1]);
+
+  dispose();
+});
+
+it("keeps a collapsed backward delete at the document start a no-op", async () => {
+  const { editor, element, getText, dispose } = init("a\nb");
+
+  element.dispatchEvent(new childWindow.FocusEvent("focus"));
+
+  // Caret at the very start of the document — there is nothing to delete
+  // backward, so the collapsed-range fallback must not underflow past 0.
+  setCaret(element.childNodes[0]!.firstChild!, 0);
+  await nextTask();
+  expect(editor.selection).toEqual([0, 0]);
+
+  const event = new childWindow.InputEvent("beforeinput", {
+    inputType: "deleteContentBackward",
+    bubbles: true,
+    cancelable: true,
+  });
+  (event as any).getTargetRanges = () => [
+    new childWindow.StaticRange({
+      startContainer: element.childNodes[0]!.firstChild!,
+      startOffset: 0,
+      endContainer: element.childNodes[0]!.firstChild!,
+      endOffset: 0,
+    }),
+  ];
+  element.dispatchEvent(event);
+  await nextTask();
+
+  expect(getText()).toBe("a\nb");
+
+  dispose();
+});

--- a/stories/repro/framework-anchor-nodes.stories.tsx
+++ b/stories/repro/framework-anchor-nodes.stories.tsx
@@ -1,0 +1,330 @@
+import React, { useEffect, useRef, useState } from "react";
+import type { StoryObj } from "@storybook/react-vite";
+import { createPlainEditor } from "../../src";
+
+export default {
+  component: createPlainEditor,
+};
+
+// Describe a DOM node for the caret readout, flagging framework anchor nodes.
+const describeNode = (node: Node | null): string => {
+  if (!node) return "none";
+  if (node.nodeType === Node.COMMENT_NODE) return "#comment (anchor)";
+  if (node.nodeType === Node.TEXT_NODE) {
+    const { data } = node as Text;
+    return data.length === 0
+      ? `#text "" (anchor)`
+      : `#text ${JSON.stringify(data)}`;
+  }
+  if (node.nodeType === Node.ELEMENT_NODE) {
+    return `<${(node as Element).tagName.toLowerCase()}>`;
+  }
+  return `node(${node.nodeType})`;
+};
+
+const makeBlock = (line: string): HTMLElement => {
+  const div = document.createElement("div");
+  div.appendChild(
+    line ? document.createTextNode(line) : document.createElement("br"),
+  );
+  return div;
+};
+
+/**
+ * Rebuilds the host's blocks, interspersing real Svelte-style anchor nodes: a
+ * leading comment and a trailing empty text node around every block, plus a
+ * final trailing comment — exactly what `{#each}` rendering dynamic components
+ * emits. Block nodes are kept in place while the block count is unchanged so the
+ * caret survives typing; only the anchor nodes make these bugs reproduce.
+ */
+const renderBlocks = (host: HTMLElement, text: string): void => {
+  const lines = text.split("\n");
+  const blocks = host.querySelectorAll(":scope > div");
+  if (blocks.length === lines.length) {
+    lines.forEach((line, i) => {
+      const block = blocks[i] as HTMLElement;
+      if (line) block.textContent = line;
+      else block.replaceChildren(document.createElement("br"));
+    });
+    return;
+  }
+  host.replaceChildren();
+  for (const line of lines) {
+    host.appendChild(document.createComment(""));
+    host.appendChild(makeBlock(line));
+    host.appendChild(document.createTextNode(""));
+  }
+  host.appendChild(document.createComment(""));
+};
+
+interface Info {
+  text: string;
+  blocks: number;
+  domCaret: string;
+}
+
+/**
+ * Shared host: a plaintext editate editor whose blocks are rendered imperatively
+ * with framework anchor nodes between and after them (see `renderBlocks`). The
+ * readouts (model text / block count / DOM caret) are the evidence, so each bug
+ * is provable from the panel below the editor without a debugger.
+ */
+function AnchorEditor({
+  initialText,
+  steps,
+  expected,
+  bug,
+  readout,
+}: {
+  initialText: string;
+  steps: React.ReactNode;
+  expected: React.ReactNode;
+  bug: React.ReactNode;
+  readout: (info: Info) => React.ReactNode;
+}) {
+  const hostRef = useRef<HTMLDivElement>(null);
+  const [text, setText] = useState(initialText);
+  const [domCaret, setDomCaret] = useState("none");
+  const [lastInput, setLastInput] = useState("none");
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+    renderBlocks(host, initialText);
+    const editor = createPlainEditor({ text: initialText, onChange: setText });
+    const cleanup = editor.input(host);
+    const onDomSel = () => {
+      const sel = document.getSelection();
+      const node = sel?.focusNode ?? null;
+      setDomCaret(
+        node && host.contains(node)
+          ? `${describeNode(node)} @ ${sel!.focusOffset}`
+          : "none",
+      );
+    };
+    document.addEventListener("selectionchange", onDomSel);
+    // Capture-phase probe: read what the browser hands editate for this delete
+    // *before* editate's own (preventDefault-ing) beforeinput handler runs. A
+    // `(collapsed)` range across the block boundary is the Firefox anchor-node
+    // bug; a `(spanning)` range means the browser expressed the merge natively.
+    const onInputProbe = (e: Event) => {
+      const ie = e as InputEvent;
+      const r = ie.getTargetRanges?.()[0];
+      // Disambiguate the host <div> from a block <div> — describeNode prints
+      // both as "<div>", which hides where the boundary actually landed.
+      const desc = (n: Node | null): string =>
+        n === host
+          ? "<div host>"
+          : n?.nodeType === Node.ELEMENT_NODE &&
+              (n as Element).tagName === "DIV" &&
+              n.parentNode === host
+            ? "<div block>"
+            : describeNode(n);
+      // NB: `range.collapsed` is a *DOM* fact. editate keys off the range after
+      // it's mapped into the document model, and a DOM-spanning range that only
+      // covers anchor nodes + an empty block serializes to a *collapsed* model
+      // range — which is the bug (see the `blocks` readout for the real verdict).
+      setLastInput(
+        !r
+          ? `${ie.inputType}: no target range (Firefox couldn't express the delete)`
+          : `${ie.inputType}: ${desc(r.startContainer)}@${r.startOffset}` +
+            ` → ${desc(r.endContainer)}@${r.endOffset} — DOM ` +
+            `${r.collapsed ? "collapsed" : "spanning"} (editate deletes only ` +
+            `if this maps to a non-collapsed model range)`,
+      );
+    };
+    host.addEventListener("beforeinput", onInputProbe, true);
+    return () => {
+      document.removeEventListener("selectionchange", onDomSel);
+      host.removeEventListener("beforeinput", onInputProbe, true);
+      cleanup();
+    };
+  }, []);
+
+  // Re-render the blocks (with anchors) whenever the model text changes.
+  useEffect(() => {
+    if (hostRef.current) renderBlocks(hostRef.current, text);
+  }, [text]);
+
+  const info: Info = { text, blocks: text.split("\n").length, domCaret };
+
+  return (
+    <div style={{ fontFamily: "sans-serif", maxWidth: 600 }}>
+      <ol>{steps}</ol>
+      <p>
+        <b>Expected:</b> {expected}
+        <br />
+        <b>Bug:</b> {bug}
+      </p>
+      <div
+        ref={hostRef}
+        style={{
+          backgroundColor: "white",
+          border: "solid 1px darkgray",
+          padding: 8,
+          minHeight: 96,
+          fontSize: 20,
+        }}
+      />
+      <pre style={{ fontSize: 14 }}>{readout(info)}</pre>
+      <pre style={{ fontSize: 12, color: "#666" }}>
+        last beforeinput:{" "}
+        <span data-testid="last-input">{lastInput}</span>
+      </pre>
+    </div>
+  );
+}
+
+/**
+ * Repro: Ctrl+A then Backspace leaves the last character behind.
+ *
+ * Firefox's Ctrl+A selects `(root, 0)..(root, childCount)`, so the end boundary
+ * lands on the trailing anchor node after the last block. `serializePosition`
+ * then climbs to the root and miscounts the inter-block separators, shifting the
+ * delete range one short — the final character is never removed.
+ *
+ * Firefox-specific (Chrome/WebKit put the Ctrl+A boundary inside the last
+ * block). Watch the `editor text` readout after the steps: empty is correct, a
+ * single leftover character is the bug.
+ */
+export const SelectAllDeletesLastCharacter: StoryObj = {
+  render: () => (
+    <AnchorEditor
+      initialText={"First block\nSecond block"}
+      steps={
+        <>
+          <li>Click into the text to focus it.</li>
+          <li>
+            Press <b>Ctrl/Cmd+A</b> to select the whole document.
+          </li>
+          <li>
+            Press <b>Backspace</b>.
+          </li>
+        </>
+      }
+      expected={
+        <>
+          the editor is empty (<code>""</code>).
+        </>
+      }
+      bug={<>the last character survives, stuck on the trailing anchor node.</>}
+      readout={({ text }) => (
+        <>
+          editor text: <span data-testid="text">{JSON.stringify(text)}</span>
+          {"\n\n"}
+          <b>
+            {text.length === 0
+              ? "✅ empty — fixed"
+              : "after Ctrl+A + Backspace, any leftover text here is the bug"}
+          </b>
+        </>
+      )}
+    />
+  ),
+};
+
+/**
+ * Repro: Backspace in an *empty* block won't merge it into the previous one.
+ *
+ * The empty block matters: with text on both sides of the boundary Firefox can
+ * anchor a spanning `deleteContentBackward` range to the real text nodes and
+ * merges natively, so the bug hides. In an empty block (just a `<br>`) the only
+ * neighbours across the boundary are anchor nodes, so Firefox can't express a
+ * spanning range and instead reports a *collapsed* one inside the empty block —
+ * the editor sees nothing to delete and the blocks never merge. The fix falls
+ * back to deleting one position backward.
+ *
+ * Firefox-specific. Watch the `blocks` readout (should drop 2 → 1) and the
+ * `last beforeinput` line (a `(collapsed …)` range is the bug).
+ */
+export const BackspaceAtBlockStartWontMerge: StoryObj = {
+  render: () => (
+    <AnchorEditor
+      initialText={"First\n"}
+      steps={
+        <>
+          <li>
+            Click into the <b>empty second line</b> (below &ldquo;First&rdquo;).
+          </li>
+          <li>
+            Press <b>Backspace</b>.
+          </li>
+        </>
+      }
+      expected={
+        <>
+          the empty block is removed, leaving one block: <code>"First"</code>.
+        </>
+      }
+      bug={
+        <>
+          nothing happens — the empty block stays. Firefox reports a{" "}
+          <i>collapsed</i> delete range inside the empty block (no text boundary
+          to span to), so editate sees nothing to delete.
+        </>
+      }
+      readout={({ text, blocks }) => (
+        <>
+          editor text: <span data-testid="text">{JSON.stringify(text)}</span>
+          {"\n"}blocks: <span data-testid="blocks">{blocks}</span>
+          {"\n\n"}
+          <b>
+            {blocks === 1
+              ? "✅ merged — fixed"
+              : "2 blocks after Backspace in the empty block is the bug"}
+          </b>
+        </>
+      )}
+    />
+  ),
+};
+
+/**
+ * Repro: clicking in the empty area below the text parks the caret on a phantom
+ * line.
+ *
+ * A trailing anchor node sits after the last block. Clicking the empty space
+ * below the text lands the native caret inside that anchor; the model offset is
+ * still correct, but the visible caret renders on a phantom line beneath the
+ * content. The fix re-anchors the DOM caret back into the real block.
+ *
+ * Most visible in Firefox. Watch the `DOM caret` readout after clicking below
+ * the text: it should point at the block's `#text`, not a `#comment`/`#text ""`
+ * anchor.
+ */
+export const ClickBelowShowsPhantomCaret: StoryObj = {
+  render: () => (
+    <AnchorEditor
+      initialText={"A simple paragraph."}
+      steps={
+        <>
+          <li>
+            Open this story in <b>Firefox</b>.
+          </li>
+          <li>
+            Click in the <b>empty area below</b> the line of text (not on the
+            text itself).
+          </li>
+        </>
+      }
+      expected={<>the caret sits at the end of the text.</>}
+      bug={
+        <>
+          the caret appears on an empty line below the text — it is parked on
+          the trailing anchor node.
+        </>
+      }
+      readout={({ domCaret }) => (
+        <>
+          DOM caret: <span data-testid="dom-caret">{domCaret}</span>
+          {"\n\n"}
+          <b>
+            {domCaret.includes("(anchor)")
+              ? "❌ caret parked on an anchor node — bug reproduced"
+              : "caret should land on the block's #text, not an anchor"}
+          </b>
+        </>
+      )}
+    />
+  ),
+};


### PR DESCRIPTION
## Summary

Frameworks like Svelte's `{#each}` (rendering dynamic components) intersperse comment / empty-text "anchor" nodes between, around, and after block elements. These are legitimate DOM, but they currently trip up selection and delete in a few browser-specific ways (all reproduced in Firefox). This PR makes editate tolerant of them, without any change to normal editing.

It's split into two commits so each bug can be verified before its fix:

1. **Add repro stories for framework anchor node bugs** — three `stories/repro` stories that reproduce the bugs *on the current code*, each with step-by-step instructions and a live readout below the editor.
2. **Handle framework anchor nodes in selection and delete** — the fixes + unit tests.

Check out commit 1 to see the stories fail, commit 2 to see them pass.

## The three fixes (commit 2)

- **`serializePosition`**: snap a boundary that lands on an anchor to the nearest selectable sibling, so Firefox's `Ctrl+A` end boundary no longer climbs to the root and miscounts the inter-block separators (which dropped the last character on delete).
- **`beforeinput`**: fall back to a one-position delete when the browser reports a *collapsed* target range for a `Backspace`/`Delete` that should cross a block boundary — Firefox does this when blocks are anchor-separated — so blocks still merge. Guarded by `isValidSelection` so an edge delete stays a no-op.
- **selection sync**: re-anchor the visible caret when the browser parks it on an anchor (Firefox's "phantom line" when you click in the empty area below the text). Only fires when an endpoint is on an anchor, so it's a no-op during normal editing.

## Repro stories (Storybook: `repro/Framework Anchor Nodes`)

- `Select All Deletes Last Character`
- `Backspace At Block Start Wont Merge`
- `Click Below Shows Phantom Caret`

Each renders its blocks with real comment/empty-text anchors interspersed (as Svelte's `{#each}` would) and shows a readout that makes the bug/fix observable.

## Notes

- **Bundle size**: the added logic pushed the `Editor` budget over — the baseline sat only ~10 B under the 5.75 kB limit — so I bumped it to `6 kB` (Total is still 8.63 / 10 kB). Happy to golf the logic instead if you'd rather hold the old budget.
- **Tests**: 536 unit tests pass, including new anchor-boundary cases in `src/dom/index.spec.ts` and a collapsed-delete case in `src/editor.window.spec.ts`.

## Test plan

- [x] `npm test`
- [x] `npm run size`
- [x] Storybook: walk the three `repro/Framework Anchor Nodes` stories in Firefox — checkout commit 1 to confirm each bug, commit 2 to confirm the fix.